### PR TITLE
feat: use light theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary
- use white background and darker text by default

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'path' or '__dirname')*
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_68949ca63614832ca0026c0281d80482