### PR TITLE
Center card grid and prevent card stretching

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -54,7 +54,7 @@ export default function Home() {
 
         <div
           className={clsx(
-            'grid gap-8 w-full',
+            'grid gap-8 justify-items-center',
             // 1‑col: mobile (<768)  |  2‑col: md (≥768)  |  3‑col: lg (≥1024)
             'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
             'px-1 sm:px-0'

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -16,7 +16,7 @@ export default function Card({ data, className = '' }: { data: CardDto, classNam
         isSelected
           ? 'border-4 border-blue-500 shadow-xl scale-105'
           : 'border border-gray-200 dark:border-gray-700 hover:border-blue-400 hover:shadow-xl',
-        'max-w-sm w-full mx-auto',
+        'max-w-sm mx-auto',
         'mb-2',
         'overflow-hidden',
         className


### PR DESCRIPTION
## Summary
- center card grid items with `justify-items-center` and remove unnecessary width
- remove `w-full` from Card article to stop cards from stretching

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894a081e490832c8a805efa43abd383