### PR TITLE
test: add Card border unit tests

### DIFF
--- a/src/tests/Card.test.tsx
+++ b/src/tests/Card.test.tsx
@@ -9,10 +9,20 @@ const stub: CardDto = { id: 99, heading: 'X', body: ['Y'], img: 'z', cta: 'Selec
 test('border switches on click', async () => {
   render(
     <UiProvider>
-      <Card data={stub} index={0} />
+      <Card data={stub} />
     </UiProvider>,
   );
   const btn = screen.getByRole('button', { name: /select/i });
   await userEvent.click(btn);
   expect(btn.closest('article')).toHaveClass('border-blue-500');
+});
+
+test('default border is gray when unselected', () => {
+  render(
+    <UiProvider>
+      <Card data={stub} />
+    </UiProvider>,
+  );
+  const btn = screen.getByRole('button', { name: /select/i });
+  expect(btn.closest('article')).toHaveClass('border-gray-200');
 });


### PR DESCRIPTION
## Summary
- add test to assert default gray border when Card is unselected
- clean up existing border toggle test

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6894a0c08274832c818c7fa908b8383f