### PR TITLE
feat: manage selected card state

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useCards } from '@/hooks/useCards';
 import Card from '@/components/Card';
 import { useUi } from '@/store/uiStore';
@@ -5,7 +6,15 @@ import clsx from 'clsx';
 
 export default function Home() {
   const { cards, status } = useCards();
-  const { toggleTheme, theme } = useUi();
+  const { toggleTheme, theme, setSelectedId } = useUi();
+
+  // highlight the middle card once cards are fetched
+  useEffect(() => {
+    if (cards.length) {
+      const middle = cards[Math.floor(cards.length / 2)];
+      setSelectedId(middle.id);
+    }
+  }, [cards, setSelectedId]);
 
   /* ----- data states ----- */
   if (status === 'loading') return <p className="text-center mt-10">Loading…</p>;

--- a/src/store/uiStore.tsx
+++ b/src/store/uiStore.tsx
@@ -9,7 +9,8 @@ interface UiState {
 const UiCtx = createContext<UiState>(null!);
 
 export const UiProvider = ({ children }: { children: ReactNode }) => {
-  const [selectedId, setSelectedId] = useState<number>(2); // middle card default
+  // default will be set to the middle card once data loads
+  const [selectedId, setSelectedId] = useState<number>(0);
   const [theme, setTheme] = useState<'light' | 'dark'>(
     localStorage.theme === 'dark' ? 'dark' : 'light',
   );

--- a/src/tests/Card.test.tsx
+++ b/src/tests/Card.test.tsx
@@ -9,10 +9,11 @@ const stub: CardDto = { id: 99, heading: 'X', body: ['Y'], img: 'z', cta: 'Selec
 test('border switches on click', async () => {
   render(
     <UiProvider>
-      <Card data={stub} index={0} />
+      <Card data={stub} />
     </UiProvider>,
   );
   const btn = screen.getByRole('button', { name: /select/i });
+  expect(btn.closest('article')).not.toHaveClass('border-blue-500');
   await userEvent.click(btn);
   expect(btn.closest('article')).toHaveClass('border-blue-500');
 });


### PR DESCRIPTION
## Summary
- track selected card in shared UI context
- select middle card on load and update selection when a card button is clicked
- adjust tests to reflect new Card API

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894a1086bfc832c9c6a4416fb07d5d4