### PR TITLE
fix: include react plugin for vitest tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
 import path from 'path'
 
 export default defineConfig({
+  plugins: [react()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- add `@vitejs/plugin-react` to Vitest config so JSX tests run without manual React imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68959e21c714832cbe1b7a88e44649a0