### PR TITLE
chore: remove duplicate tests folder

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: 'tests/setup.ts',
+    setupFiles: 'test/setup.ts',
   },
 })


### PR DESCRIPTION
## Summary
- remove redundant `tests` directory
- point Vitest setupFiles to `test/setup.ts`

## Testing
- `npm test` *(fails: React is not defined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895a094b2c4832c9d1ce59c5f8b3c02