### PR TITLE
test: mock matchMedia for node

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,1 +1,26 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// Vitest's node runtime lacks `window.matchMedia`, which some components
+// rely on. Define a minimal stub so tests can execute without throwing.
+
+// Ensure a global `window` object exists when running in a pure Node
+// environment.
+// @ts-expect-error: define `window` for Node runtime
+if (typeof window === 'undefined') global.window = {} as Window;
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- stub `window.matchMedia` in test setup so Vitest can run in a Node runtime

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895ad43df64832ca4098f5b053ddf29