### PR TITLE
chore: configure vitest globals for eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,4 +20,10 @@ export default tseslint.config([
       globals: globals.browser,
     },
   },
+  {
+    files: ['test/**/*.{ts,tsx}'],
+    languageOptions: {
+      globals: { ...globals.browser, ...globals.vitest },
+    },
+  },
 ])


### PR DESCRIPTION
## Summary
- add vitest environment globals to eslint for test files

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b53abba0832c8c4540354cad9b95