### PR TITLE
test: mock cards API with msw

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4",
     "vitest": "^3.2.4",
-    "@vitest/ui": "^3.2.4"
+    "@vitest/ui": "^3.2.4",
+    "msw": "^2.4.9"
   }
 }

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from 'msw';
+import type { CardDto } from '@/types';
+
+const cards: CardDto[] = [
+  { id: 1, heading: 'Test Card', body: ['Lorem ipsum'], img: '/img.jpg', cta: 'Select' }
+];
+
+export const handlers = [
+  http.get('/data/cards.json', () => HttpResponse.json(cards)),
+];

--- a/test/mocks/server.ts
+++ b/test/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
-import { vi } from 'vitest';
+import { vi, beforeAll, afterEach, afterAll } from 'vitest';
+import { server } from './mocks/server';
 
 // Vitest's node runtime lacks `window.matchMedia`, which some components
 // rely on. Define a minimal stub so tests can execute without throwing.
@@ -24,3 +25,7 @@ if (!window.matchMedia) {
     })),
   });
 }
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/test/useCards.test.ts
+++ b/test/useCards.test.ts
@@ -1,0 +1,11 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useCards } from '@/hooks/useCards';
+
+// ensure msw mock data is used
+
+it('fetches cards from API', async () => {
+  const { result } = renderHook(() => useCards());
+  await waitFor(() => expect(result.current.status).toBe('done'));
+  expect(result.current.cards).toHaveLength(1);
+  expect(result.current.cards[0].heading).toBe('Test Card');
+});


### PR DESCRIPTION
## Summary
- add msw to dev dependencies
- mock `/data/cards.json` requests and run server during tests
- add test covering mocked `useCards` hook

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to resolve import "msw/node" from "test/mocks/server.ts". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_6895b72146a8832c88c0de17420bd1c1