### PR TITLE
test: group Card tests with describe block

### DIFF
--- a/test/Card.test.tsx
+++ b/test/Card.test.tsx
@@ -6,24 +6,26 @@ import type { CardDto } from '@/types';
 
 const stub: CardDto = { id: 99, heading: 'X', body: ['Y'], img: 'z', cta: 'Select' };
 
-test('border switches on click', async () => {
-  render(
-    <UiProvider>
-      <Card data={stub} />
-    </UiProvider>,
-  );
-  const btn = screen.getByRole('button', { name: /select/i });
-  expect(btn.closest('article')).not.toHaveClass('border-blue-500');
-  await userEvent.click(btn);
-  expect(btn.closest('article')).toHaveClass('border-blue-500');
-});
+describe('Card', () => {
+  it('border switches on click', async () => {
+    render(
+      <UiProvider>
+        <Card data={stub} />
+      </UiProvider>,
+    );
+    const btn = screen.getByRole('button', { name: /select/i });
+    expect(btn.closest('article')).not.toHaveClass('border-blue-500');
+    await userEvent.click(btn);
+    expect(btn.closest('article')).toHaveClass('border-blue-500');
+  });
 
-test('default border is gray when unselected', () => {
-  render(
-    <UiProvider>
-      <Card data={stub} />
-    </UiProvider>,
-  );
-  const btn = screen.getByRole('button', { name: /select/i });
-  expect(btn.closest('article')).toHaveClass('border-gray-200');
+  it('default border is gray when unselected', () => {
+    render(
+      <UiProvider>
+        <Card data={stub} />
+      </UiProvider>,
+    );
+    const btn = screen.getByRole('button', { name: /select/i });
+    expect(btn.closest('article')).toHaveClass('border-gray-200');
+  });
 });


### PR DESCRIPTION
## Summary
- group Card component tests under a describe block
- use `it` instead of `test` for individual cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689704279e70832c9d1bb8b5bbaa4830