### PR TITLE
refactor card test for reuse

### DIFF
--- a/test/Card.test.tsx
+++ b/test/Card.test.tsx
@@ -6,26 +6,27 @@ import type { CardDto } from '@/types';
 
 const stub: CardDto = { id: 99, heading: 'X', body: ['Y'], img: 'z', cta: 'Select' };
 
+const renderCard = (data: CardDto = stub) => {
+  render(
+    <UiProvider>
+      <Card data={data} />
+    </UiProvider>,
+  );
+
+  const button = screen.getByRole('button', { name: /select/i });
+  return { button, card: button.closest('article') };
+};
+
 describe('Card', () => {
   it('border switches on click', async () => {
-    render(
-      <UiProvider>
-        <Card data={stub} />
-      </UiProvider>,
-    );
-    const btn = screen.getByRole('button', { name: /select/i });
-    expect(btn.closest('article')).not.toHaveClass('border-blue-500');
-    await userEvent.click(btn);
-    expect(btn.closest('article')).toHaveClass('border-blue-500');
+    const { button, card } = renderCard();
+    expect(card).not.toHaveClass('border-blue-500');
+    await userEvent.click(button);
+    expect(card).toHaveClass('border-blue-500');
   });
 
   it('default border is gray when unselected', () => {
-    render(
-      <UiProvider>
-        <Card data={stub} />
-      </UiProvider>,
-    );
-    const btn = screen.getByRole('button', { name: /select/i });
-    expect(btn.closest('article')).toHaveClass('border-gray-200');
+    const { card } = renderCard();
+    expect(card).toHaveClass('border-gray-200');
   });
 });


### PR DESCRIPTION
## Summary
- add render helper to Card tests for cleaner reuse

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689705b5a318832c971d67c785ab119a